### PR TITLE
Add CompactNSearch

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,7 +19,7 @@ project("DCA" VERSION 0.1
 find_package(Eigen3 REQUIRED NO_MODULE)
 set(CMAKE_CXX_STANDARD 20)
 
-cmake_policy(SET CMP0077 OLD) # let us overwrite options in subprojects
+cmake_policy(SET CMP0077 NEW) # let us overwrite options in subprojects
 
 option(BUILD_EXAMPLES "Build examples" ON)
 option(USE_COMPACT_N_SEARCH "Build a Pair generator with the help of CompactNSearch" ON)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,6 +19,7 @@ project("DCA" VERSION 0.1
 find_package(Eigen3 REQUIRED NO_MODULE)
 set(CMAKE_CXX_STANDARD 20)
 
+cmake_policy(SET CMP0077 OLD) # let us overwrite options in subprojects
 
 option(BUILD_EXAMPLES "Build examples" ON)
 option(USE_COMPACT_N_SEARCH "Build a Pair generator with the help of CompactNSearch" ON)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,11 +1,27 @@
 cmake_minimum_required(VERSION 3.16)
 
+# FetchContent command is available with cmake >= 3.11
+include(FetchContent)
+
+macro(fetch what)
+    FetchContent_GetProperties("${what}")
+    if(NOT ${${what}_POPULATED})
+        message(STATUS "fetching ${what} ...")
+        FetchContent_Populate(${what})
+    endif()
+    mark_as_advanced(${${what}_SOURCE_DIR})
+endmacro()
+
 project("DCA" VERSION 0.1
              DESCRIPTION "Differentiable Collision Avoidance"
              HOMEPAGE_URL "https://github.com/SimiPro/DCA")
 
 find_package(Eigen3 REQUIRED NO_MODULE)
 set(CMAKE_CXX_STANDARD 20)
+
+
+option(BUILD_EXAMPLES "Build examples" ON)
+option(USE_COMPACT_N_SEARCH "Build a Pair generator with the help of CompactNSearch" ON)
 
 add_library(${PROJECT_NAME} INTERFACE)
 
@@ -17,8 +33,29 @@ target_include_directories(
 target_compile_features(${PROJECT_NAME} INTERFACE cxx_std_20)
 target_link_libraries(${PROJECT_NAME} INTERFACE Eigen3::Eigen)
 
-option(BUILD_EXAMPLES "Build examples" ON)
+if(${USE_COMPACT_N_SEARCH})
+
+  target_compile_definitions(${PROJECT_NAME} INTERFACE -DBUILD_COMPACT_N_SEARCH=1)
+  
+  FetchContent_Declare(
+    compactnsearch #
+    GIT_REPOSITORY https://github.com/digitalillusions/CompactNSearch.git #
+    GIT_TAG 011eb171c2cbfa536cd47b6a6ffdf90c9b0d40fd #
+  )
+  set(USE_DOUBLE_PRECISION ON) # Tell CompactNSearch to use doubles instead of floats
+  fetch(compactnsearch)
+  add_subdirectory(${compactnsearch_SOURCE_DIR} CompactNSearch)
+  
+  target_link_libraries(${PROJECT_NAME} INTERFACE CompactNSearch)
+
+else(${USE_COMPACT_N_SEARCH})
+
+  target_compile_definitions(${PROJECT_NAME} INTERFACE -DBUILD_COMPACT_N_SEARCH=0)
+
+endif(${USE_COMPACT_N_SEARCH})
 
 if(${BUILD_EXAMPLES})
+
   add_subdirectory(examples)
-endif(${BUILD_EXAMPLES})
+
+  endif(${BUILD_EXAMPLES})

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,8 +19,6 @@ project("DCA" VERSION 0.1
 find_package(Eigen3 REQUIRED NO_MODULE)
 set(CMAKE_CXX_STANDARD 20)
 
-cmake_policy(SET CMP0077 NEW) # let us overwrite options in subprojects
-
 option(BUILD_EXAMPLES "Build examples" ON)
 option(USE_COMPACT_N_SEARCH "Build a Pair generator with the help of CompactNSearch" ON)
 
@@ -43,7 +41,7 @@ if(${USE_COMPACT_N_SEARCH})
     GIT_REPOSITORY https://github.com/digitalillusions/CompactNSearch.git #
     GIT_TAG 011eb171c2cbfa536cd47b6a6ffdf90c9b0d40fd #
   )
-  set(USE_DOUBLE_PRECISION ON) # Tell CompactNSearch to use doubles instead of floats
+  set(USE_DOUBLE_PRECISION ON CACHE INTERNAL "") # Tell CompactNSearch to use doubles instead of floats
   fetch(compactnsearch)
   add_subdirectory(${compactnsearch_SOURCE_DIR} CompactNSearch)
   

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -1,8 +1,18 @@
 cmake_minimum_required(VERSION 3.16)
 
-project(examples)
+project(example)
 
-add_executable(example example.cpp)
+add_executable(${PROJECT_NAME} example.cpp)
 
 # Link to DCA and make the header files accessible only to this executable.
-target_link_libraries(example PRIVATE DCA)
+target_link_libraries(${PROJECT_NAME} PRIVATE DCA)
+
+if(${USE_COMPACT_N_SEARCH})
+
+  target_compile_definitions(${PROJECT_NAME} PRIVATE -DBUILD_COMPACT_N_SEARCH=1)
+
+else(${USE_COMPACT_N_SEARCH})
+
+  target_compile_definitions(${PROJECT_NAME} PRIVATE -DBUILD_COMPACT_N_SEARCH=0)
+
+endif(${USE_COMPACT_N_SEARCH})

--- a/examples/example.cpp
+++ b/examples/example.cpp
@@ -24,14 +24,26 @@ int main(int argc, char const* argv[]) {
 
     // Create all possible permutations for the given primitives
     PermutationPairGenerator ppg;
-    auto pairs = ppg.generate(primitives);
+    auto pairs_permutatation = ppg.generate(primitives);
+    std::cout << "Permutation reported " << pairs_permutatation.size()
+              << " pairs." << std::endl;
+
+#if BUILD_COMPACT_N_SEARCH
+
+    NeighborsPairGenerator npg(2.);
+    auto pairs_neighbors = npg.generate(primitives);
+
+    std::cout << "Neighbors reported " << pairs_neighbors.size() << " pairs."
+              << std::endl;
+
+#endif
 
     // Temporary storage for the gradient and hessian
     VectorXd grad;
     MatrixXd hess;
 
     // Iterate over each pair and print out the distance and derivatives.
-    for (auto& pair : pairs) {
+    for (auto& pair : pairs_permutatation) {
         std::cout << "Distance: " << compute_D(pair, primitives) << std::endl;
 
         compute_dDdP(grad, pair, primitives);

--- a/include/DCA/pair.h
+++ b/include/DCA/pair.h
@@ -11,7 +11,15 @@
 #ifndef __DCA_PAIR_H__
 #define __DCA_PAIR_H__
 
+#include "primitives.h"
 #include "utils.h"
+
+#if BUILD_COMPACT_N_SEARCH
+
+#include <CompactNSearch>
+#include <exception>
+
+#endif /* BUILD_COMPACT_N_SEARCH */
 
 namespace DCA {
 /**
@@ -51,5 +59,62 @@ public:
         return ret;
     }
 };
+
+#if BUILD_COMPACT_N_SEARCH
+class NeighborsPairGenerator : public PairGenerator {
+public:
+    NeighborsPairGenerator(const double &radius) : m_radius(radius) {}
+
+    virtual std::vector<pair_t> generate(
+        const std::vector<primitive_t> &primitives) const override {
+        std::vector<pair_t> ret;
+
+        std::vector<std::array<double, 3>> positions;
+        positions.resize(primitives.size());
+        // Create the position vector
+
+        for (size_t i = 0; i < primitives.size(); i++) {
+            Vector3d pos = std::visit(
+                overloaded{[](const Sphere &cp) { return cp.getPosition(); },
+                           [](const Capsule &cp) {
+                               return Vector3d(0.5 * (cp.getStartPosition() +
+                                                      cp.getEndPosition()));
+                           },
+                           [](const primitive_t &cp) {
+                               throw std::logic_error(
+                                   "Could not get primitive position. Missing "
+                                   "overload.");
+                               return 0.;
+                           }},
+                primitives[i]);
+            positions[i] = {pos.x(), pos.y(), pos.z()};
+        }
+
+        CompactNSearch::NeighborhoodSearch nsearch(m_radius);
+        unsigned id =
+            nsearch.add_point_set(positions.front().data(), positions.size());
+
+        // Actually perform the computation
+        nsearch.find_neighbors();
+
+        // Now get all neighbors and add them to the pairs list
+        CompactNSearch::PointSet const &ps = nsearch.point_set(id);
+        for (int i = 0; i < ps.n_points(); i++) {
+            for (size_t j = 0; j < ps.n_neighbors(id, i); j++) {
+                // return point id of the j-th neighbor of the i-th particle in the point set
+                const unsigned pid = ps.neighbor(id, i, j);
+
+                ret.push_back({i, pid});
+            }
+        }
+
+        return ret;
+    }
+
+private:
+    double m_radius;
+};
+#endif /* BUILD_COMPACT_N_SEARCH */
+
 }  // namespace DCA
 #endif /* __DCA_PAIR_H__ */

--- a/include/DCA/primitives.h
+++ b/include/DCA/primitives.h
@@ -70,6 +70,10 @@ public:
     compute_dDdP_FD(Capsule);
     compute_d2DdP2_FD(Capsule);
 
+    // Helpers
+    Vector3d getPosition() const { return m_position; }
+    double getRadius() const { return m_radius; }
+
 private:
     Vector3d m_position;
     double m_radius;
@@ -95,6 +99,10 @@ public:
     compute_d2DdP2_FD(Sphere);
     compute_d2DdP2_FD(Capsule);
 
+    // Helpers
+    Vector3d getStartPosition() const { return m_startPosition; }
+    Vector3d getEndPosition() const { return m_endPosition; }
+    double getRadius() const { return m_radius; }
 private:
     Vector3d m_startPosition;
     Vector3d m_endPosition;

--- a/include/DCA/utils.h
+++ b/include/DCA/utils.h
@@ -39,6 +39,11 @@ using Eigen::VectorXd;
 // Easier access to a pair (corresponding of two indices)
 using pair_t = std::pair<size_t, size_t>;
 
+// Helper for std::visit
+template<class... Ts> struct overloaded : Ts... { using Ts::operator()...; };
+template<class... Ts> overloaded(Ts...) -> overloaded<Ts...>;
+
+
 #define EPSILON 1e-8
 
 /**


### PR DESCRIPTION
This pull request adds the possibility to use [CompactNSearch](https://github.com/InteractiveComputerGraphics/CompactNSearch) to generate possible collision pairs (based on a given radius).

The library will be fetched during compile time (not as a submodule).

There is a CMake-Option called `USE_COMPACT_N_SEARCH` which toggles whether this is used or not.

Furthermore, it also adds the availabilty for primitives to get private data members (getters), as those are needed for a single position for the pair generator.