### PR TITLE
CI: Add Windows

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -3,10 +3,16 @@ name: Build
 on: [push, pull_request]
 
 jobs:
-  ubuntu-build:
-    runs-on: ubuntu-latest
+  build:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest, windows-latest]
+        configs: [Release, Debug]
     steps:
     - name: Checkout
       uses: actions/checkout@v2.0.0
     - name: Build project
-      uses: nicledomaS/cmake_build_action@v1.3
+      uses: nicledomaS/cmake_build_action@v1.4
+      with:
+        config: ${{ matrix.configs }}


### PR DESCRIPTION
This PR adds a Windows target to the continuous integration. Furthermore, both Release and Debug mode are built on Linux and Windows.