### PR TITLE
Improve pair generation

### DIFF
--- a/examples/example.cpp
+++ b/examples/example.cpp
@@ -32,8 +32,6 @@ int main(int argc, char const* argv[]) {
             std::cout << p.first << "/" << p.second << std::endl;
     }
 
-#if BUILD_COMPACT_N_SEARCH
-
     NeighborsPairGenerator npg(2.);
     auto pairs_neighbors = npg.generate(primitives);
 
@@ -42,8 +40,6 @@ int main(int argc, char const* argv[]) {
     for(auto& p : pairs_neighbors) {
             std::cout << p.first << "/" << p.second << std::endl;
     }
-
-#endif
 
     // Temporary storage for the gradient and hessian
     VectorXd grad;

--- a/include/DCA/Pair.h
+++ b/include/DCA/Pair.h
@@ -68,7 +68,7 @@ public:
         const override;  // namespace DCA
 
 private:
-    double m_radius2;  ///< The squared radius
+    double m_radius;  ///< The radius
 };
 
 }  // namespace DCA

--- a/include/DCA/Pair.h
+++ b/include/DCA/Pair.h
@@ -4,31 +4,12 @@
 
 namespace DCA {
 
-#ifndef DOXYGEN_SHOULD_SKIP_THIS
-/**
- * @brief This is the base class for all generators.
- */
-class PairGenerator {
-public:
-    /**
-     * @brief This function generates the pairs given the primitives.
-     * 
-     * The returned vector consists of pairs, where each pair holds two numbers:
-     * The indices of the corresponding primitives which were given.
-     * @param[in] primitives All primitives to generate the pairs from.
-     * @return A vector of pairs of indices, where each index corresponds to a primitive in the primitives vector.
-     */
-    virtual std::vector<pair_t> generate(
-        const std::vector<primitive_t> &primitives) const = 0;
-};
-#endif /* DOXYGEN_SHOULD_SKIP_THIS */
-
 /**
  * @brief This generator creates all possible permutations of pairs.
  * This means, the amount of pairs created is \f$n^2/2\f$, where n is the number of primitives.
  * Pairs are not returned twice (0, 1) and (1, 0).
  */
-class PermutationPairGenerator : public PairGenerator {
+class PermutationPairGenerator {
 public:
     /**
      * @brief This function generates all pairs given the primitives.
@@ -38,8 +19,8 @@ public:
      * @param[in] primitives All primitives to generate the pairs from.
      * @return A vector of pairs of indices, where each index corresponds to a primitive in the primitives vector.
      */
-    virtual std::vector<pair_t> generate(
-        const std::vector<primitive_t> &primitives) const override;
+    std::vector<pair_t> generate(
+        const std::vector<primitive_t> &primitives) const;
 };
 
 /**
@@ -47,7 +28,7 @@ public:
  * It does so by computing a single position for each primitive and selecting
  * pairs based on the distance.
  */
-class NeighborsPairGenerator : public PairGenerator {
+class NeighborsPairGenerator {
 public:
     /**
      * @brief Construct this generator with a given radius
@@ -63,9 +44,23 @@ public:
      * @param[in] primitives All primitives to generate the pairs from.
      * @return A vector of pairs of indices, where each index corresponds to a primitive in the primitives vector.
      */
-    virtual std::vector<pair_t> generate(
-        const std::vector<primitive_t> &primitives)
-        const override;  // namespace DCA
+    std::vector<pair_t> generate(
+        const std::vector<primitive_t> &primitives) const;  // namespace DCA
+
+    /**
+     * @brief This function generates pairs given two vectors of primitives, where the pairs are in a certain distance from each other and are in separate vectors.
+     * 
+     * The returned vector consists of pairs, where each pair holds two numbers:
+     * The indices of the corresponding primitives which were given. The first index corresponds to the primitives_a vector, the second to the primitives_b vector.
+     * @param[in] primitives_a The first set of primitives.
+     * @param[in] primitives_b The second set of primitives.
+     * @return A vector of pairs of indices, where the first index corresponds to a primitive in the primitives_a vector and the second index to the primitives_b vector.
+     * 
+     * @attention Not all pairs are reported, only those between primitives_a and primitives_b!
+     */
+    std::vector<pair_t> generate(
+        const std::vector<primitive_t> &primitives_a,
+        const std::vector<primitive_t> &primitives_b) const;
 
 private:
     double m_radius;  ///< The radius

--- a/src/Pair.cpp
+++ b/src/Pair.cpp
@@ -1,5 +1,6 @@
 #include <DCA/Interactions/PlaneVsSphere.h>
 #include <DCA/Pair.h>
+#include <DCA/API.h>
 
 namespace DCA {
 
@@ -20,88 +21,20 @@ std::vector<pair_t> PermutationPairGenerator::generate(
 }
 
 NeighborsPairGenerator::NeighborsPairGenerator(const double &radius)
-    : m_radius2(radius * radius) {}
+    : m_radius(radius) {}
 
 std::vector<pair_t> NeighborsPairGenerator::generate(
     const std::vector<primitive_t> &primitives) const {
     std::vector<pair_t> ret;
 
-    std::vector<Vector3d> positions(primitives.size());
-
-    for (size_t i = 0; i < primitives.size(); i++) {
-        Vector3d pos = std::visit(
-            overloaded{
-                [](const Sphere &cp) { return cp.position; },
-                [](const Capsule &cp) {
-                    return Vector3d(0.5 * (cp.startPosition + cp.endPosition));
-                },
-                [](const Plane &cp) {
-                    return cp.point;  // palceholder. Will be checked later.
-                }},
-            primitives[i]);
-        positions[i] = {pos.x(), pos.y(), pos.z()};
-    }
-
     // now search all pairs where they are in a certain distance
     for (size_t i = 0; i < primitives.size(); i++) {
-        // skip primitve self-collision, therefore start at i + 1
+        // skip primitive self-collision, therefore start at i + 1
         for (size_t j = i + 1; j < primitives.size(); j++) {
-            std::visit(
-                overloaded{
-                    [&](const Plane &p, const Plane &other) {
-                        // compare normals, if dot product = 1 or -1 --> dist.
-                        // else: 0
-                        double normals = p.normal.dot(other.normal);
-                        if (fabs(fabs(normals) - 1.) < 1e-8) {
-                            // check if distance fullfilled
-                            Vector6d P_plane;
-                            P_plane << p.point, p.normal;
-                            Vector3d pt_on_plane =
-                                PlaneVsSphere::getProjectionOfPoint(
-                                    P_plane, other.point);
-                            if ((pt_on_plane - positions[j]).squaredNorm() <
-                                m_radius2) {
-                                ret.push_back({i, j});
-                            }
-                        } else {
-                            // intersecting, return pair
-                            ret.push_back({i, j});
-                        }
-                    },
-                    [&](const Plane &p, const primitive_t &other) {
-                        // map pos. of other to the plane
-                        Vector6d P_plane;
-                        P_plane << p.point, p.normal;
-                        Vector3d pt_on_plane =
-                            PlaneVsSphere::getProjectionOfPoint(P_plane,
-                                                                positions[j]);
-                        // now check distance
-                        if ((pt_on_plane - positions[j]).squaredNorm() <
-                            m_radius2) {
-                            ret.push_back({i, j});
-                        }
-                    },
-                    [&](const primitive_t &other, const Plane &p) {
-                        // map pos. of other to the plane
-                        Vector6d P_plane;
-                        P_plane << p.point, p.normal;
-                        Vector3d pt_on_plane =
-                            PlaneVsSphere::getProjectionOfPoint(P_plane,
-                                                                positions[i]);
-                        // now check distance
-                        if ((pt_on_plane - positions[i]).squaredNorm() <
-                            m_radius2) {
-                            ret.push_back({i, j});
-                        }
-                    },
-                    [&](const primitive_t &a, const primitive_t &b) {
-                        // if two "normal" primitives, compare positions
-                        if ((positions[i] - positions[j]).squaredNorm() <
-                            m_radius2) {
-                            ret.push_back({i, j});
-                        }
-                    }},
-                primitives.at(i), primitives.at(j));
+            double distance = API::compute_D(primitives.at(i), primitives.at(j));
+            if (distance < m_radius) {
+                ret.push_back({i, j});
+            }
         }
     }
 

--- a/src/Pair.cpp
+++ b/src/Pair.cpp
@@ -1,6 +1,6 @@
+#include <DCA/API.h>
 #include <DCA/Interactions/PlaneVsSphere.h>
 #include <DCA/Pair.h>
-#include <DCA/API.h>
 
 namespace DCA {
 
@@ -31,7 +31,8 @@ std::vector<pair_t> NeighborsPairGenerator::generate(
     for (size_t i = 0; i < primitives.size(); i++) {
         // skip primitive self-collision, therefore start at i + 1
         for (size_t j = i + 1; j < primitives.size(); j++) {
-            double distance = API::compute_D(primitives.at(i), primitives.at(j));
+            double distance =
+                API::compute_D(primitives.at(i), primitives.at(j));
             if (distance < m_radius) {
                 ret.push_back({i, j});
             }
@@ -40,4 +41,23 @@ std::vector<pair_t> NeighborsPairGenerator::generate(
 
     return ret;
 }
+
+std::vector<pair_t> NeighborsPairGenerator::generate(
+    const std::vector<primitive_t> &primitives_a,
+    const std::vector<primitive_t> &primitives_b) const {
+    std::vector<pair_t> ret;
+
+    for (size_t i = 0; i < primitives_a.size(); i++) {
+        for (size_t j = 0; j < primitives_b.size(); j++) {
+            double distance =
+                API::compute_D(primitives_a.at(i), primitives_b.at(j));
+            if (distance < m_radius) {
+                ret.push_back({i, j});
+            }
+        }
+    }
+    
+    return ret;
+}
+
 }  // namespace DCA


### PR DESCRIPTION
The new (better) pair generation uses the `compute_D` functionality which is already in place for all pairs of primitives. It returns all pairs where the distance between is smaller than the search radius.